### PR TITLE
ルプガナ関係フラグのバグを修正

### DIFF
--- a/src/dq2pswd/dq2pswd.ts
+++ b/src/dq2pswd/dq2pswd.ts
@@ -393,7 +393,7 @@ export const flagPlumageLabels: ReadonlyArray<LabelInfo> = [
 export const statShipLabels: ReadonlyArray<LabelInfo> = [
   { id: 0, name: '何もしていない' },
   { id: 1, name: '女の子を助けた' },
-  { id: 2, name: '（不正な状態）', illegal: true },
+  { id: 2, name: '（船をもらった）' },
   { id: 3, name: '船をもらった' },
 ];
 
@@ -924,10 +924,6 @@ const isValidItems = (items: number[], mask: number): boolean => {
 export const checkInfo = (info: Dq2PasswordInfo): boolean => {
   if (info.checkCode !== 0) {
     // チェックコードがあっていない
-    return false;
-  }
-  if (info.statShip === 2) {
-    // ルプガナの街の船のステータス不正
     return false;
   }
   if (EXP_MAX_VALUE < info.roExp) {

--- a/src/dq2pswd/dq2pswd.ts
+++ b/src/dq2pswd/dq2pswd.ts
@@ -393,8 +393,8 @@ export const flagPlumageLabels: ReadonlyArray<LabelInfo> = [
 export const statShipLabels: ReadonlyArray<LabelInfo> = [
   { id: 0, name: '何もしていない' },
   { id: 1, name: '女の子を助けた' },
-  { id: 2, name: '船をもらった' },
-  { id: 3, name: '（不正な状態）', illegal: true },
+  { id: 2, name: '（不正な状態）', illegal: true },
+  { id: 3, name: '船をもらった' },
 ];
 
 export const statPrinceLabels: ReadonlyArray<LabelInfo> = [
@@ -443,7 +443,7 @@ export interface Dq2PasswordInfo {
   flagGate: boolean;
   /** 「みずのはごろも」を false:織ってもらっていない, true:織ってもらった */
   flagPlumage: boolean;
-  /** ルプガナの街で 0:何もしていない, 1:女の子を助けた, 2:船をもらった */
+  /** ルプガナの街で 0:何もしていない, 1:女の子を助けた, 3:船をもらった */
   statShip: number;
   /** サマルトリアの王子を 0:見つけていない, 1:探して、王様にあった, 2:探して、勇者の泉に行った, 3:見つけた */
   statPrince: number;
@@ -926,7 +926,7 @@ export const checkInfo = (info: Dq2PasswordInfo): boolean => {
     // チェックコードがあっていない
     return false;
   }
-  if (info.statShip === 3) {
+  if (info.statShip === 2) {
     // ルプガナの街の船のステータス不正
     return false;
   }


### PR DESCRIPTION
ルプガナ関係のフラグの値が間違っているようです。「船を入手した」と「女の子を助けた」は別々の1ビットのフラグで、10のとき女の子を助けていないのに船を入手していることになり、不正な状態です。船を入手したときは11になります。

覚えている呪文を入力してみたらルプガナ関係フラグが「不正な状態」になったので気づきました。というかよっちさんご自身が過去に公開していたサイトの復活の呪文をInternet Archiveから拾ってきて入力しても「不正な状態」になります(ですから当時公開されていたCGIは正しい処理をしていたはずです)。

修正したプログラムを実際にビルドして確認はしていないのでもしかしたらうまく直っていないかもしれませんが、その場合は適当に対応してください。